### PR TITLE
Fix linter to work with no-console rule

### DIFF
--- a/linter/ast.js
+++ b/linter/ast.js
@@ -1,0 +1,516 @@
+module.exports = {
+  type: "Program",
+  start: 0,
+  end: 56,
+  loc: {
+    start: {
+      line: 1,
+      column: 0,
+    },
+    end: {
+      line: 3,
+      column: 22,
+    },
+  },
+  range: [0, 56],
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 23,
+      loc: {
+        start: {
+          line: 1,
+          column: 0,
+        },
+        end: {
+          line: 1,
+          column: 23,
+        },
+      },
+      range: [0, 23],
+      expression: {
+        type: "CallExpression",
+        start: 0,
+        end: 22,
+        loc: {
+          start: {
+            line: 1,
+            column: 0,
+          },
+          end: {
+            line: 1,
+            column: 22,
+          },
+        },
+        range: [0, 22],
+        callee: {
+          type: "MemberExpression",
+          start: 0,
+          end: 11,
+          loc: {
+            start: {
+              line: 1,
+              column: 0,
+            },
+            end: {
+              line: 1,
+              column: 11,
+            },
+          },
+          range: [0, 11],
+          object: {
+            type: "Identifier",
+            start: 0,
+            end: 7,
+            loc: {
+              start: {
+                line: 1,
+                column: 0,
+              },
+              end: {
+                line: 1,
+                column: 7,
+              },
+            },
+            range: [0, 7],
+            name: "console",
+          },
+          property: {
+            type: "Identifier",
+            start: 8,
+            end: 11,
+            loc: {
+              start: {
+                line: 1,
+                column: 8,
+              },
+              end: {
+                line: 1,
+                column: 11,
+              },
+            },
+            range: [8, 11],
+            name: "log",
+          },
+          computed: false,
+        },
+        arguments: [
+          {
+            type: "Literal",
+            start: 12,
+            end: 21,
+            loc: {
+              start: {
+                line: 1,
+                column: 12,
+              },
+              end: {
+                line: 1,
+                column: 21,
+              },
+            },
+            range: [12, 21],
+            value: "hello, ",
+            raw: '"hello, "',
+          },
+        ],
+      },
+    },
+    {
+      type: "DebuggerStatement",
+      start: 24,
+      end: 33,
+      loc: {
+        start: {
+          line: 2,
+          column: 0,
+        },
+        end: {
+          line: 2,
+          column: 9,
+        },
+      },
+      range: [24, 33],
+    },
+    {
+      type: "ExpressionStatement",
+      start: 34,
+      end: 56,
+      loc: {
+        start: {
+          line: 3,
+          column: 0,
+        },
+        end: {
+          line: 3,
+          column: 22,
+        },
+      },
+      range: [34, 56],
+      expression: {
+        type: "CallExpression",
+        start: 34,
+        end: 55,
+        loc: {
+          start: {
+            line: 3,
+            column: 0,
+          },
+          end: {
+            line: 3,
+            column: 21,
+          },
+        },
+        range: [34, 55],
+        callee: {
+          type: "MemberExpression",
+          start: 34,
+          end: 45,
+          loc: {
+            start: {
+              line: 3,
+              column: 0,
+            },
+            end: {
+              line: 3,
+              column: 11,
+            },
+          },
+          range: [34, 45],
+          object: {
+            type: "Identifier",
+            start: 34,
+            end: 41,
+            loc: {
+              start: {
+                line: 3,
+                column: 0,
+              },
+              end: {
+                line: 3,
+                column: 7,
+              },
+            },
+            range: [34, 41],
+            name: "console",
+          },
+          property: {
+            type: "Identifier",
+            start: 42,
+            end: 45,
+            loc: {
+              start: {
+                line: 3,
+                column: 8,
+              },
+              end: {
+                line: 3,
+                column: 11,
+              },
+            },
+            range: [42, 45],
+            name: "log",
+          },
+          computed: false,
+        },
+        arguments: [
+          {
+            type: "Literal",
+            start: 46,
+            end: 54,
+            loc: {
+              start: {
+                line: 3,
+                column: 12,
+              },
+              end: {
+                line: 3,
+                column: 20,
+              },
+            },
+            range: [46, 54],
+            value: "world!",
+            raw: '"world!"',
+          },
+        ],
+      },
+    },
+  ],
+  sourceType: "module",
+  comments: [],
+  tokens: [
+    {
+      type: "Identifier",
+      value: "console",
+      start: 0,
+      end: 7,
+      loc: {
+        start: {
+          line: 1,
+          column: 0,
+        },
+        end: {
+          line: 1,
+          column: 7,
+        },
+      },
+      range: [0, 7],
+    },
+    {
+      type: "Punctuator",
+      value: ".",
+      start: 7,
+      end: 8,
+      loc: {
+        start: {
+          line: 1,
+          column: 7,
+        },
+        end: {
+          line: 1,
+          column: 8,
+        },
+      },
+      range: [7, 8],
+    },
+    {
+      type: "Identifier",
+      value: "log",
+      start: 8,
+      end: 11,
+      loc: {
+        start: {
+          line: 1,
+          column: 8,
+        },
+        end: {
+          line: 1,
+          column: 11,
+        },
+      },
+      range: [8, 11],
+    },
+    {
+      type: "Punctuator",
+      value: "(",
+      start: 11,
+      end: 12,
+      loc: {
+        start: {
+          line: 1,
+          column: 11,
+        },
+        end: {
+          line: 1,
+          column: 12,
+        },
+      },
+      range: [11, 12],
+    },
+    {
+      type: "String",
+      value: '"hello, "',
+      start: 12,
+      end: 21,
+      loc: {
+        start: {
+          line: 1,
+          column: 12,
+        },
+        end: {
+          line: 1,
+          column: 21,
+        },
+      },
+      range: [12, 21],
+    },
+    {
+      type: "Punctuator",
+      value: ")",
+      start: 21,
+      end: 22,
+      loc: {
+        start: {
+          line: 1,
+          column: 21,
+        },
+        end: {
+          line: 1,
+          column: 22,
+        },
+      },
+      range: [21, 22],
+    },
+    {
+      type: "Punctuator",
+      value: ";",
+      start: 22,
+      end: 23,
+      loc: {
+        start: {
+          line: 1,
+          column: 22,
+        },
+        end: {
+          line: 1,
+          column: 23,
+        },
+      },
+      range: [22, 23],
+    },
+    {
+      type: "Keyword",
+      value: "debugger",
+      start: 24,
+      end: 32,
+      loc: {
+        start: {
+          line: 2,
+          column: 0,
+        },
+        end: {
+          line: 2,
+          column: 8,
+        },
+      },
+      range: [24, 32],
+    },
+    {
+      type: "Punctuator",
+      value: ";",
+      start: 32,
+      end: 33,
+      loc: {
+        start: {
+          line: 2,
+          column: 8,
+        },
+        end: {
+          line: 2,
+          column: 9,
+        },
+      },
+      range: [32, 33],
+    },
+    {
+      type: "Identifier",
+      value: "console",
+      start: 34,
+      end: 41,
+      loc: {
+        start: {
+          line: 3,
+          column: 0,
+        },
+        end: {
+          line: 3,
+          column: 7,
+        },
+      },
+      range: [34, 41],
+    },
+    {
+      type: "Punctuator",
+      value: ".",
+      start: 41,
+      end: 42,
+      loc: {
+        start: {
+          line: 3,
+          column: 7,
+        },
+        end: {
+          line: 3,
+          column: 8,
+        },
+      },
+      range: [41, 42],
+    },
+    {
+      type: "Identifier",
+      value: "log",
+      start: 42,
+      end: 45,
+      loc: {
+        start: {
+          line: 3,
+          column: 8,
+        },
+        end: {
+          line: 3,
+          column: 11,
+        },
+      },
+      range: [42, 45],
+    },
+    {
+      type: "Punctuator",
+      value: "(",
+      start: 45,
+      end: 46,
+      loc: {
+        start: {
+          line: 3,
+          column: 11,
+        },
+        end: {
+          line: 3,
+          column: 12,
+        },
+      },
+      range: [45, 46],
+    },
+    {
+      type: "String",
+      value: '"world!"',
+      start: 46,
+      end: 54,
+      loc: {
+        start: {
+          line: 3,
+          column: 12,
+        },
+        end: {
+          line: 3,
+          column: 20,
+        },
+      },
+      range: [46, 54],
+    },
+    {
+      type: "Punctuator",
+      value: ")",
+      start: 54,
+      end: 55,
+      loc: {
+        start: {
+          line: 3,
+          column: 20,
+        },
+        end: {
+          line: 3,
+          column: 21,
+        },
+      },
+      range: [54, 55],
+    },
+    {
+      type: "Punctuator",
+      value: ";",
+      start: 55,
+      end: 56,
+      loc: {
+        start: {
+          line: 3,
+          column: 21,
+        },
+        end: {
+          line: 3,
+          column: 22,
+        },
+      },
+      range: [55, 56],
+    },
+  ],
+};

--- a/linter/linter.js
+++ b/linter/linter.js
@@ -59,6 +59,8 @@ const runRules = (ast, rules) => {
   });
 
   traverse(
+    // NOTE: this wrapper is required in order for traverse() to visit
+    // the 'Program' node at the root of `ast`.
     {
       type: "File",
       program: ast,

--- a/linter/linter.js
+++ b/linter/linter.js
@@ -1,9 +1,7 @@
-const { parse } = require("@babel/parser");
 const traverse = require("@babel/traverse").default;
 const { SourceCode } = require("eslint");
-const convertAST = require("../node_modules/@babel/eslint-parser/lib/convert/convertAST.cjs");
-
-console.log("traverse = ", traverse);
+const evk = require("eslint-visitor-keys");
+const eslintScope = require("eslint-scope");
 
 const noDebugger = require("../node_modules/eslint/lib/rules/no-debugger.js");
 const noConsole = require("../node_modules/eslint/lib/rules/no-console.js");
@@ -14,60 +12,599 @@ debugger;
 console.log("world!");
 `;
 
-const ast = convertAST(
-  parse(input, {
-    sourceType: "module",
-    loc: true,
-    sourceFilename: "test.js",
-    tokens: true,
-    ranges: true,
-  })
-);
-
-console.log(ast);
-
-const sourceCode = new SourceCode(input, ast);
+const ast = {
+  type: "Program",
+  start: 0,
+  end: 56,
+  loc: {
+    start: {
+      line: 1,
+      column: 0,
+    },
+    end: {
+      line: 3,
+      column: 22,
+    },
+  },
+  range: [0, 56],
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 23,
+      loc: {
+        start: {
+          line: 1,
+          column: 0,
+        },
+        end: {
+          line: 1,
+          column: 23,
+        },
+      },
+      range: [0, 23],
+      expression: {
+        type: "CallExpression",
+        start: 0,
+        end: 22,
+        loc: {
+          start: {
+            line: 1,
+            column: 0,
+          },
+          end: {
+            line: 1,
+            column: 22,
+          },
+        },
+        range: [0, 22],
+        callee: {
+          type: "MemberExpression",
+          start: 0,
+          end: 11,
+          loc: {
+            start: {
+              line: 1,
+              column: 0,
+            },
+            end: {
+              line: 1,
+              column: 11,
+            },
+          },
+          range: [0, 11],
+          object: {
+            type: "Identifier",
+            start: 0,
+            end: 7,
+            loc: {
+              start: {
+                line: 1,
+                column: 0,
+              },
+              end: {
+                line: 1,
+                column: 7,
+              },
+            },
+            range: [0, 7],
+            name: "console",
+          },
+          property: {
+            type: "Identifier",
+            start: 8,
+            end: 11,
+            loc: {
+              start: {
+                line: 1,
+                column: 8,
+              },
+              end: {
+                line: 1,
+                column: 11,
+              },
+            },
+            range: [8, 11],
+            name: "log",
+          },
+          computed: false,
+        },
+        arguments: [
+          {
+            type: "Literal",
+            start: 12,
+            end: 21,
+            loc: {
+              start: {
+                line: 1,
+                column: 12,
+              },
+              end: {
+                line: 1,
+                column: 21,
+              },
+            },
+            range: [12, 21],
+            value: "hello, ",
+            raw: '"hello, "',
+          },
+        ],
+      },
+    },
+    {
+      type: "DebuggerStatement",
+      start: 24,
+      end: 33,
+      loc: {
+        start: {
+          line: 2,
+          column: 0,
+        },
+        end: {
+          line: 2,
+          column: 9,
+        },
+      },
+      range: [24, 33],
+    },
+    {
+      type: "ExpressionStatement",
+      start: 34,
+      end: 56,
+      loc: {
+        start: {
+          line: 3,
+          column: 0,
+        },
+        end: {
+          line: 3,
+          column: 22,
+        },
+      },
+      range: [34, 56],
+      expression: {
+        type: "CallExpression",
+        start: 34,
+        end: 55,
+        loc: {
+          start: {
+            line: 3,
+            column: 0,
+          },
+          end: {
+            line: 3,
+            column: 21,
+          },
+        },
+        range: [34, 55],
+        callee: {
+          type: "MemberExpression",
+          start: 34,
+          end: 45,
+          loc: {
+            start: {
+              line: 3,
+              column: 0,
+            },
+            end: {
+              line: 3,
+              column: 11,
+            },
+          },
+          range: [34, 45],
+          object: {
+            type: "Identifier",
+            start: 34,
+            end: 41,
+            loc: {
+              start: {
+                line: 3,
+                column: 0,
+              },
+              end: {
+                line: 3,
+                column: 7,
+              },
+            },
+            range: [34, 41],
+            name: "console",
+          },
+          property: {
+            type: "Identifier",
+            start: 42,
+            end: 45,
+            loc: {
+              start: {
+                line: 3,
+                column: 8,
+              },
+              end: {
+                line: 3,
+                column: 11,
+              },
+            },
+            range: [42, 45],
+            name: "log",
+          },
+          computed: false,
+        },
+        arguments: [
+          {
+            type: "Literal",
+            start: 46,
+            end: 54,
+            loc: {
+              start: {
+                line: 3,
+                column: 12,
+              },
+              end: {
+                line: 3,
+                column: 20,
+              },
+            },
+            range: [46, 54],
+            value: "world!",
+            raw: '"world!"',
+          },
+        ],
+      },
+    },
+  ],
+  sourceType: "module",
+  comments: [],
+  tokens: [
+    {
+      type: "Identifier",
+      value: "console",
+      start: 0,
+      end: 7,
+      loc: {
+        start: {
+          line: 1,
+          column: 0,
+        },
+        end: {
+          line: 1,
+          column: 7,
+        },
+      },
+      range: [0, 7],
+    },
+    {
+      type: "Punctuator",
+      value: ".",
+      start: 7,
+      end: 8,
+      loc: {
+        start: {
+          line: 1,
+          column: 7,
+        },
+        end: {
+          line: 1,
+          column: 8,
+        },
+      },
+      range: [7, 8],
+    },
+    {
+      type: "Identifier",
+      value: "log",
+      start: 8,
+      end: 11,
+      loc: {
+        start: {
+          line: 1,
+          column: 8,
+        },
+        end: {
+          line: 1,
+          column: 11,
+        },
+      },
+      range: [8, 11],
+    },
+    {
+      type: "Punctuator",
+      value: "(",
+      start: 11,
+      end: 12,
+      loc: {
+        start: {
+          line: 1,
+          column: 11,
+        },
+        end: {
+          line: 1,
+          column: 12,
+        },
+      },
+      range: [11, 12],
+    },
+    {
+      type: "String",
+      value: '"hello, "',
+      start: 12,
+      end: 21,
+      loc: {
+        start: {
+          line: 1,
+          column: 12,
+        },
+        end: {
+          line: 1,
+          column: 21,
+        },
+      },
+      range: [12, 21],
+    },
+    {
+      type: "Punctuator",
+      value: ")",
+      start: 21,
+      end: 22,
+      loc: {
+        start: {
+          line: 1,
+          column: 21,
+        },
+        end: {
+          line: 1,
+          column: 22,
+        },
+      },
+      range: [21, 22],
+    },
+    {
+      type: "Punctuator",
+      value: ";",
+      start: 22,
+      end: 23,
+      loc: {
+        start: {
+          line: 1,
+          column: 22,
+        },
+        end: {
+          line: 1,
+          column: 23,
+        },
+      },
+      range: [22, 23],
+    },
+    {
+      type: "Keyword",
+      value: "debugger",
+      start: 24,
+      end: 32,
+      loc: {
+        start: {
+          line: 2,
+          column: 0,
+        },
+        end: {
+          line: 2,
+          column: 8,
+        },
+      },
+      range: [24, 32],
+    },
+    {
+      type: "Punctuator",
+      value: ";",
+      start: 32,
+      end: 33,
+      loc: {
+        start: {
+          line: 2,
+          column: 8,
+        },
+        end: {
+          line: 2,
+          column: 9,
+        },
+      },
+      range: [32, 33],
+    },
+    {
+      type: "Identifier",
+      value: "console",
+      start: 34,
+      end: 41,
+      loc: {
+        start: {
+          line: 3,
+          column: 0,
+        },
+        end: {
+          line: 3,
+          column: 7,
+        },
+      },
+      range: [34, 41],
+    },
+    {
+      type: "Punctuator",
+      value: ".",
+      start: 41,
+      end: 42,
+      loc: {
+        start: {
+          line: 3,
+          column: 7,
+        },
+        end: {
+          line: 3,
+          column: 8,
+        },
+      },
+      range: [41, 42],
+    },
+    {
+      type: "Identifier",
+      value: "log",
+      start: 42,
+      end: 45,
+      loc: {
+        start: {
+          line: 3,
+          column: 8,
+        },
+        end: {
+          line: 3,
+          column: 11,
+        },
+      },
+      range: [42, 45],
+    },
+    {
+      type: "Punctuator",
+      value: "(",
+      start: 45,
+      end: 46,
+      loc: {
+        start: {
+          line: 3,
+          column: 11,
+        },
+        end: {
+          line: 3,
+          column: 12,
+        },
+      },
+      range: [45, 46],
+    },
+    {
+      type: "String",
+      value: '"world!"',
+      start: 46,
+      end: 54,
+      loc: {
+        start: {
+          line: 3,
+          column: 12,
+        },
+        end: {
+          line: 3,
+          column: 20,
+        },
+      },
+      range: [46, 54],
+    },
+    {
+      type: "Punctuator",
+      value: ")",
+      start: 54,
+      end: 55,
+      loc: {
+        start: {
+          line: 3,
+          column: 20,
+        },
+        end: {
+          line: 3,
+          column: 21,
+        },
+      },
+      range: [54, 55],
+    },
+    {
+      type: "Punctuator",
+      value: ";",
+      start: 55,
+      end: 56,
+      loc: {
+        start: {
+          line: 3,
+          column: 21,
+        },
+        end: {
+          line: 3,
+          column: 22,
+        },
+      },
+      range: [55, 56],
+    },
+  ],
+};
 
 const adaptVisitor = (visitor) => {
-  const newVisitor = {};
-
-  for (const [key, value] of Object.entries(visitor)) {
-    // TODO: handle cases where both :enter and :exit are present
-    if (key.endsWith(":exit")) {
-      newVisitor[key.replace(":exit", "")] = {
-        exit: (path) => {
-          value(path.node);
-        },
-      };
-    } else {
-      newVisitor[key] = (path) => {
-        value(path.node);
-      };
-    }
-  }
-
-  return newVisitor;
+  return {
+    enter(path) {
+      const { node } = path;
+      node.parent = path.parentPath?.node;
+      if (node.type in visitor) {
+        return visitor[node.type](node);
+      } else if (`${node.type}:enter` in visitor) {
+        return visitor[`${node.type}:enter`](node);
+      }
+    },
+    exit(path) {
+      const { node } = path;
+      node.parent = path.parentPath?.node;
+      if (`${node.type}:exit` in visitor) {
+        return visitor[`${node.type}:exit`](node);
+      }
+    },
+  };
 };
 
 const rules = [noDebugger, noConsole];
 
-const runRule = (ast, rule) => {
-  const visitor = rule.create({
-    report: ({ node, messageId }) => {
-      const message = rule.meta.messages[messageId];
-      console.log(message);
-      console.log("location = ", node.loc);
-    },
-    options: {}, // TODO: populate with options from .eslintrc.js
-    sourceCode,
-  });
+const runRule = (program, sourceCode, rule) => {
+  const visitor = adaptVisitor(
+    rule.create({
+      report: ({ node, messageId }) => {
+        const message = rule.meta.messages[messageId];
+        const start = `${node.loc.start.line}:${node.loc.start.column}`;
+        const end = `${node.loc.end.line}:${node.loc.end.column}`;
+        console.log(`${start} to ${end} - ${message}`);
+      },
+      options: {}, // TODO: populate with options from .eslintrc.js
+      sourceCode,
+    })
+  );
 
-  traverse(ast, adaptVisitor(visitor));
+  traverse(
+    {
+      type: "File",
+      program,
+    },
+    visitor
+  );
+};
+
+const DEFAULT_ECMA_VERSION = 5;
+
+const analyzeScope = (ast, languageOptions, visitorKeys) => {
+  const parserOptions = languageOptions.parserOptions;
+  const ecmaFeatures = parserOptions.ecmaFeatures || {};
+  const ecmaVersion = languageOptions.ecmaVersion || DEFAULT_ECMA_VERSION;
+
+  return eslintScope.analyze(ast, {
+    ignoreEval: true,
+    nodejsScope: ecmaFeatures.globalReturn,
+    impliedStrict: ecmaFeatures.impliedStrict,
+    ecmaVersion: typeof ecmaVersion === "number" ? ecmaVersion : 6,
+    sourceType: languageOptions.sourceType || "script",
+    childVisitorKeys: visitorKeys || evk.KEYS,
+    fallback: evk.getKeys,
+  });
 };
 
 const runRules = (ast, rules) => {
+  const scopeManager = analyzeScope(ast, { parserOptions: {} });
+  const config = {
+    text: input,
+    ast,
+    undefined, // ParserServices | undefined,
+    scopeManager,
+  };
+  const sourceCode = new SourceCode(config);
+
   for (const rule of rules) {
-    runRule(ast, rule);
+    runRule(ast, sourceCode, rule);
   }
 };
 

--- a/linter/linter.js
+++ b/linter/linter.js
@@ -6,574 +6,14 @@ const eslintScope = require("eslint-scope");
 const noDebugger = require("../node_modules/eslint/lib/rules/no-debugger.js");
 const noConsole = require("../node_modules/eslint/lib/rules/no-console.js");
 
+const ast = require("./ast.js");
 const input = `
 console.log("hello, ");
 debugger;
 console.log("world!");
 `;
 
-const ast = {
-  type: "Program",
-  start: 0,
-  end: 56,
-  loc: {
-    start: {
-      line: 1,
-      column: 0,
-    },
-    end: {
-      line: 3,
-      column: 22,
-    },
-  },
-  range: [0, 56],
-  body: [
-    {
-      type: "ExpressionStatement",
-      start: 0,
-      end: 23,
-      loc: {
-        start: {
-          line: 1,
-          column: 0,
-        },
-        end: {
-          line: 1,
-          column: 23,
-        },
-      },
-      range: [0, 23],
-      expression: {
-        type: "CallExpression",
-        start: 0,
-        end: 22,
-        loc: {
-          start: {
-            line: 1,
-            column: 0,
-          },
-          end: {
-            line: 1,
-            column: 22,
-          },
-        },
-        range: [0, 22],
-        callee: {
-          type: "MemberExpression",
-          start: 0,
-          end: 11,
-          loc: {
-            start: {
-              line: 1,
-              column: 0,
-            },
-            end: {
-              line: 1,
-              column: 11,
-            },
-          },
-          range: [0, 11],
-          object: {
-            type: "Identifier",
-            start: 0,
-            end: 7,
-            loc: {
-              start: {
-                line: 1,
-                column: 0,
-              },
-              end: {
-                line: 1,
-                column: 7,
-              },
-            },
-            range: [0, 7],
-            name: "console",
-          },
-          property: {
-            type: "Identifier",
-            start: 8,
-            end: 11,
-            loc: {
-              start: {
-                line: 1,
-                column: 8,
-              },
-              end: {
-                line: 1,
-                column: 11,
-              },
-            },
-            range: [8, 11],
-            name: "log",
-          },
-          computed: false,
-        },
-        arguments: [
-          {
-            type: "Literal",
-            start: 12,
-            end: 21,
-            loc: {
-              start: {
-                line: 1,
-                column: 12,
-              },
-              end: {
-                line: 1,
-                column: 21,
-              },
-            },
-            range: [12, 21],
-            value: "hello, ",
-            raw: '"hello, "',
-          },
-        ],
-      },
-    },
-    {
-      type: "DebuggerStatement",
-      start: 24,
-      end: 33,
-      loc: {
-        start: {
-          line: 2,
-          column: 0,
-        },
-        end: {
-          line: 2,
-          column: 9,
-        },
-      },
-      range: [24, 33],
-    },
-    {
-      type: "ExpressionStatement",
-      start: 34,
-      end: 56,
-      loc: {
-        start: {
-          line: 3,
-          column: 0,
-        },
-        end: {
-          line: 3,
-          column: 22,
-        },
-      },
-      range: [34, 56],
-      expression: {
-        type: "CallExpression",
-        start: 34,
-        end: 55,
-        loc: {
-          start: {
-            line: 3,
-            column: 0,
-          },
-          end: {
-            line: 3,
-            column: 21,
-          },
-        },
-        range: [34, 55],
-        callee: {
-          type: "MemberExpression",
-          start: 34,
-          end: 45,
-          loc: {
-            start: {
-              line: 3,
-              column: 0,
-            },
-            end: {
-              line: 3,
-              column: 11,
-            },
-          },
-          range: [34, 45],
-          object: {
-            type: "Identifier",
-            start: 34,
-            end: 41,
-            loc: {
-              start: {
-                line: 3,
-                column: 0,
-              },
-              end: {
-                line: 3,
-                column: 7,
-              },
-            },
-            range: [34, 41],
-            name: "console",
-          },
-          property: {
-            type: "Identifier",
-            start: 42,
-            end: 45,
-            loc: {
-              start: {
-                line: 3,
-                column: 8,
-              },
-              end: {
-                line: 3,
-                column: 11,
-              },
-            },
-            range: [42, 45],
-            name: "log",
-          },
-          computed: false,
-        },
-        arguments: [
-          {
-            type: "Literal",
-            start: 46,
-            end: 54,
-            loc: {
-              start: {
-                line: 3,
-                column: 12,
-              },
-              end: {
-                line: 3,
-                column: 20,
-              },
-            },
-            range: [46, 54],
-            value: "world!",
-            raw: '"world!"',
-          },
-        ],
-      },
-    },
-  ],
-  sourceType: "module",
-  comments: [],
-  tokens: [
-    {
-      type: "Identifier",
-      value: "console",
-      start: 0,
-      end: 7,
-      loc: {
-        start: {
-          line: 1,
-          column: 0,
-        },
-        end: {
-          line: 1,
-          column: 7,
-        },
-      },
-      range: [0, 7],
-    },
-    {
-      type: "Punctuator",
-      value: ".",
-      start: 7,
-      end: 8,
-      loc: {
-        start: {
-          line: 1,
-          column: 7,
-        },
-        end: {
-          line: 1,
-          column: 8,
-        },
-      },
-      range: [7, 8],
-    },
-    {
-      type: "Identifier",
-      value: "log",
-      start: 8,
-      end: 11,
-      loc: {
-        start: {
-          line: 1,
-          column: 8,
-        },
-        end: {
-          line: 1,
-          column: 11,
-        },
-      },
-      range: [8, 11],
-    },
-    {
-      type: "Punctuator",
-      value: "(",
-      start: 11,
-      end: 12,
-      loc: {
-        start: {
-          line: 1,
-          column: 11,
-        },
-        end: {
-          line: 1,
-          column: 12,
-        },
-      },
-      range: [11, 12],
-    },
-    {
-      type: "String",
-      value: '"hello, "',
-      start: 12,
-      end: 21,
-      loc: {
-        start: {
-          line: 1,
-          column: 12,
-        },
-        end: {
-          line: 1,
-          column: 21,
-        },
-      },
-      range: [12, 21],
-    },
-    {
-      type: "Punctuator",
-      value: ")",
-      start: 21,
-      end: 22,
-      loc: {
-        start: {
-          line: 1,
-          column: 21,
-        },
-        end: {
-          line: 1,
-          column: 22,
-        },
-      },
-      range: [21, 22],
-    },
-    {
-      type: "Punctuator",
-      value: ";",
-      start: 22,
-      end: 23,
-      loc: {
-        start: {
-          line: 1,
-          column: 22,
-        },
-        end: {
-          line: 1,
-          column: 23,
-        },
-      },
-      range: [22, 23],
-    },
-    {
-      type: "Keyword",
-      value: "debugger",
-      start: 24,
-      end: 32,
-      loc: {
-        start: {
-          line: 2,
-          column: 0,
-        },
-        end: {
-          line: 2,
-          column: 8,
-        },
-      },
-      range: [24, 32],
-    },
-    {
-      type: "Punctuator",
-      value: ";",
-      start: 32,
-      end: 33,
-      loc: {
-        start: {
-          line: 2,
-          column: 8,
-        },
-        end: {
-          line: 2,
-          column: 9,
-        },
-      },
-      range: [32, 33],
-    },
-    {
-      type: "Identifier",
-      value: "console",
-      start: 34,
-      end: 41,
-      loc: {
-        start: {
-          line: 3,
-          column: 0,
-        },
-        end: {
-          line: 3,
-          column: 7,
-        },
-      },
-      range: [34, 41],
-    },
-    {
-      type: "Punctuator",
-      value: ".",
-      start: 41,
-      end: 42,
-      loc: {
-        start: {
-          line: 3,
-          column: 7,
-        },
-        end: {
-          line: 3,
-          column: 8,
-        },
-      },
-      range: [41, 42],
-    },
-    {
-      type: "Identifier",
-      value: "log",
-      start: 42,
-      end: 45,
-      loc: {
-        start: {
-          line: 3,
-          column: 8,
-        },
-        end: {
-          line: 3,
-          column: 11,
-        },
-      },
-      range: [42, 45],
-    },
-    {
-      type: "Punctuator",
-      value: "(",
-      start: 45,
-      end: 46,
-      loc: {
-        start: {
-          line: 3,
-          column: 11,
-        },
-        end: {
-          line: 3,
-          column: 12,
-        },
-      },
-      range: [45, 46],
-    },
-    {
-      type: "String",
-      value: '"world!"',
-      start: 46,
-      end: 54,
-      loc: {
-        start: {
-          line: 3,
-          column: 12,
-        },
-        end: {
-          line: 3,
-          column: 20,
-        },
-      },
-      range: [46, 54],
-    },
-    {
-      type: "Punctuator",
-      value: ")",
-      start: 54,
-      end: 55,
-      loc: {
-        start: {
-          line: 3,
-          column: 20,
-        },
-        end: {
-          line: 3,
-          column: 21,
-        },
-      },
-      range: [54, 55],
-    },
-    {
-      type: "Punctuator",
-      value: ";",
-      start: 55,
-      end: 56,
-      loc: {
-        start: {
-          line: 3,
-          column: 21,
-        },
-        end: {
-          line: 3,
-          column: 22,
-        },
-      },
-      range: [55, 56],
-    },
-  ],
-};
-
-const adaptVisitor = (visitor) => {
-  return {
-    enter(path) {
-      const { node } = path;
-      node.parent = path.parentPath?.node;
-      if (node.type in visitor) {
-        return visitor[node.type](node);
-      } else if (`${node.type}:enter` in visitor) {
-        return visitor[`${node.type}:enter`](node);
-      }
-    },
-    exit(path) {
-      const { node } = path;
-      node.parent = path.parentPath?.node;
-      if (`${node.type}:exit` in visitor) {
-        return visitor[`${node.type}:exit`](node);
-      }
-    },
-  };
-};
-
 const rules = [noDebugger, noConsole];
-
-const runRule = (program, sourceCode, rule) => {
-  const visitor = adaptVisitor(
-    rule.create({
-      report: ({ node, messageId }) => {
-        const message = rule.meta.messages[messageId];
-        const start = `${node.loc.start.line}:${node.loc.start.column}`;
-        const end = `${node.loc.end.line}:${node.loc.end.column}`;
-        console.log(`${start} to ${end} - ${message}`);
-      },
-      options: {}, // TODO: populate with options from .eslintrc.js
-      sourceCode,
-    })
-  );
-
-  traverse(
-    {
-      type: "File",
-      program,
-    },
-    visitor
-  );
-};
 
 const DEFAULT_ECMA_VERSION = 5;
 
@@ -594,18 +34,58 @@ const analyzeScope = (ast, languageOptions, visitorKeys) => {
 };
 
 const runRules = (ast, rules) => {
-  const scopeManager = analyzeScope(ast, { parserOptions: {} });
   const config = {
     text: input,
     ast,
     undefined, // ParserServices | undefined,
-    scopeManager,
+    scopeManager: analyzeScope(ast, {
+      ecmaVersion: 13, // ES2022
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    }),
   };
   const sourceCode = new SourceCode(config);
 
-  for (const rule of rules) {
-    runRule(ast, sourceCode, rule);
-  }
+  const visitors = rules.map((rule) => {
+    return rule.create({
+      report: ({ node, messageId }) => {
+        const message = rule.meta.messages[messageId];
+        const start = `${node.loc.start.line}:${node.loc.start.column}`;
+        const end = `${node.loc.end.line}:${node.loc.end.column}`;
+        console.log(`${start} to ${end} - ${message}`);
+      },
+      options: {}, // TODO: populate with options from .eslintrc.js
+      sourceCode,
+    });
+  });
+
+  traverse(
+    {
+      type: "File",
+      program: ast,
+    },
+    {
+      enter(path) {
+        const { node } = path;
+        node.parent = path.parentPath?.node;
+        for (const visitor of visitors) {
+          if (node.type in visitor) {
+            return visitor[node.type](node);
+          } else if (`${node.type}:enter` in visitor) {
+            return visitor[`${node.type}:enter`](node);
+          }
+        }
+      },
+      exit(path) {
+        const { node } = path;
+        node.parent = path.parentPath?.node;
+        for (const visitor of visitors) {
+          if (`${node.type}:exit` in visitor) {
+            return visitor[`${node.type}:exit`](node);
+          }
+        }
+      },
+    }
+  );
 };
 
 runRules(ast, rules);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@babel/traverse": "^7.22.11",
     "eslint": "^8.48.0",
     "eslint-scope": "^7.2.2",
-    "eslint-visitor-keys": "^3.4.3",
-    "swc-to-babel": "^2.2.0"
+    "eslint-visitor-keys": "^3.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,12 +6,10 @@
   "author": "Kevin Barabash <kevinb7@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@babel/eslint-parser": "^7.22.11",
     "@babel/traverse": "^7.22.11",
     "eslint": "^8.48.0",
+    "eslint-scope": "^7.2.2",
+    "eslint-visitor-keys": "^3.4.3",
     "swc-to-babel": "^2.2.0"
-  },
-  "devDependencies": {
-    "@babel/parser": "^7.22.14"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,15 +15,6 @@
     "@babel/highlight" "^7.22.13"
     chalk "^2.4.2"
 
-"@babel/eslint-parser@^7.22.11":
-  version "7.22.11"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.22.11.tgz#cceb8c7989c241a16dd14e12a6cd725618f3f58b"
-  integrity sha512-YjOYZ3j7TjV8OhLW6NCtyg8G04uStATEUe5eiLuCZaXz2VSDQ3dsAtm2D+TuQyAqNMUK2WacGo0/uma9Pein1w==
-  dependencies:
-    "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
-    eslint-visitor-keys "^2.1.0"
-    semver "^6.3.1"
-
 "@babel/generator@^7.22.10":
   version "7.22.10"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.10.tgz#c92254361f398e160645ac58831069707382b722"
@@ -84,11 +75,6 @@
   version "7.22.13"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.13.tgz#23fb17892b2be7afef94f573031c2f4b42839a2b"
   integrity sha512-3l6+4YOvc9wx7VlCSw4yQfcBo01ECA8TicQfbnCPuCEpRQrf+gTUyGdxNw+pyTUyywp6JRD1w0YQs9TpBXYlkw==
-
-"@babel/parser@^7.22.14":
-  version "7.22.14"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.14.tgz#c7de58e8de106e88efca42ce17f0033209dfd245"
-  integrity sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==
 
 "@babel/template@^7.22.5":
   version "7.22.5"
@@ -206,13 +192,6 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
-  version "5.1.1-v1"
-  resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz#dbf733a965ca47b1973177dc0bb6c889edcfb129"
-  integrity sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==
-  dependencies:
-    eslint-scope "5.1.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -454,14 +433,6 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-scope@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
-  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
-  dependencies:
-    esrecurse "^4.3.0"
-    estraverse "^4.1.1"
-
 eslint-scope@^7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"
@@ -469,11 +440,6 @@ eslint-scope@^7.2.2:
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
-
-eslint-visitor-keys@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
-  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
@@ -545,11 +511,6 @@ esrecurse@^4.3.0:
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
-
-estraverse@^4.1.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
-  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.3.0"
@@ -885,11 +846,6 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
-
-semver@^6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 shebang-command@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,7 +71,7 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.18.13", "@babel/parser@^7.22.11", "@babel/parser@^7.22.5":
+"@babel/parser@^7.22.11", "@babel/parser@^7.22.5":
   version "7.22.13"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.13.tgz#23fb17892b2be7afef94f573031c2f4b42839a2b"
   integrity sha512-3l6+4YOvc9wx7VlCSw4yQfcBo01ECA8TicQfbnCPuCEpRQrf+gTUyGdxNw+pyTUyywp6JRD1w0YQs9TpBXYlkw==
@@ -85,7 +85,7 @@
     "@babel/parser" "^7.22.5"
     "@babel/types" "^7.22.5"
 
-"@babel/traverse@^7.1.6", "@babel/traverse@^7.22.11":
+"@babel/traverse@^7.22.11":
   version "7.22.11"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.11.tgz#71ebb3af7a05ff97280b83f05f8865ac94b2027c"
   integrity sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==
@@ -101,7 +101,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.2.0", "@babel/types@^7.22.10", "@babel/types@^7.22.11", "@babel/types@^7.22.5":
+"@babel/types@^7.22.10", "@babel/types@^7.22.11", "@babel/types@^7.22.5":
   version "7.22.11"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.11.tgz#0e65a6a1d4d9cbaa892b2213f6159485fe632ea2"
   integrity sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==
@@ -213,79 +213,6 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
-
-"@swc/core-darwin-arm64@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.80.tgz#18be1879ffc0a871a7397ccccf8a80278a794d60"
-  integrity sha512-rhoFTcQMUGfO7IkfOnopPSF6O0/aVJ58B7KueIKbvrMe6YvSfFj9QfObELFjYCcrJZTvUWBhig0QrsfPIiUphA==
-
-"@swc/core-darwin-x64@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.80.tgz#83413aed20751e836139be0aa2f6f419850bad41"
-  integrity sha512-0dOLedFpVXe+ugkKHXsqSxMKqvQYfFtibWbrZ7j8wOaErzSGPr0VpyWvepNVb9s046725kPXSw+fsGhqZR8wrw==
-
-"@swc/core-linux-arm-gnueabihf@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.80.tgz#caa6608103dfce820d071ca59cd52617e0c96804"
-  integrity sha512-QIjwP3PtDeHBDkwF6+ZZqdUsqAhORbMpxrw2jq3mHe4lQrxBttSFTq018vlMRo2mFEorOvXdadzaD9m+NymPrw==
-
-"@swc/core-linux-arm64-gnu@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.80.tgz#0ec3962eb196cc5f99b8540f89fafb75366092ce"
-  integrity sha512-cg8WriIueab58ZwkzXmIACnjSzFLzOBwxlC9k65gPXMNgCjab2YbqEYvAbjBqneuqaao02gW6tad2uhjgYaExw==
-
-"@swc/core-linux-arm64-musl@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.80.tgz#4c2f58fb10b6d163bf22ab517a3afacd7016d670"
-  integrity sha512-AhdCQ7QKx5mWrtpaOA1mFRiWWvuiiUtspvo0QSpspDetRKTND1rlf/3UB5+gp0kCeCNUTsVmJWU7fIA9ICZtXA==
-
-"@swc/core-linux-x64-gnu@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.80.tgz#de94d37953d46ac2321b96c35849beffaed60beb"
-  integrity sha512-+2e5oni1vOrLIjM5Q2/GIzK/uS2YEtuJqnjPvCK8SciRJsSl8OgVsRvyCDbmKeZNtJ2Q+o/O2AQ2w1qpAJG6jg==
-
-"@swc/core-linux-x64-musl@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.80.tgz#30e7dd46f30a8027bc6864c10666a98003f715ab"
-  integrity sha512-8OK9IlI1zpWOm7vIp1iXmZSEzLAwFpqhsGSEhxPavpOx2m54kLFdPcw/Uv3n461f6TCtszIxkGq1kSqBUdfUBA==
-
-"@swc/core-win32-arm64-msvc@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.80.tgz#cab6e1140c19b3576204da995f6dd719d6bb7417"
-  integrity sha512-RKhatwiAGlffnF6z2Mm3Ddid0v3KB+uf5m/Gc7N9zO/EUAV0PnHRuYuZSGyqodHmGFC+mK8YrCooFCEmHL9n+w==
-
-"@swc/core-win32-ia32-msvc@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.80.tgz#3da4715e77c6f1559a3a76cca80fddee9aa100fc"
-  integrity sha512-3jiiZzU/kaw7k4zUp1yMq1QiUe4wJVtCEXIhf+fKuBsIwm7rdvyK/+PIx5KHnZy4TGQnYczKBRhJA5nuBcrUCQ==
-
-"@swc/core-win32-x64-msvc@1.3.80":
-  version "1.3.80"
-  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.80.tgz#2693dd16176b181f440127c822f7006ffba8d3ad"
-  integrity sha512-2eZtIoIWQBWqykfms92Zd37lveYOBWQTZjdooBGlsLHtcoQLkNpf1NXmR6TKY0yy8q6Yl3OhPvY+izjmO08MSg==
-
-"@swc/core@^1.3.69":
-  version "1.3.80"
-  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.80.tgz#364570b0cd5bba7ff686888558bbfd6423317310"
-  integrity sha512-yX2xV5I/lYswHHR+44TPvzBgq3/Y8N1YWpTQADYuvSiX3Jxyvemk5Jpx3rRtigYb8WBkWAAf2i5d5ZJ2M7hhgw==
-  dependencies:
-    "@swc/types" "^0.1.3"
-  optionalDependencies:
-    "@swc/core-darwin-arm64" "1.3.80"
-    "@swc/core-darwin-x64" "1.3.80"
-    "@swc/core-linux-arm-gnueabihf" "1.3.80"
-    "@swc/core-linux-arm64-gnu" "1.3.80"
-    "@swc/core-linux-arm64-musl" "1.3.80"
-    "@swc/core-linux-x64-gnu" "1.3.80"
-    "@swc/core-linux-x64-musl" "1.3.80"
-    "@swc/core-win32-arm64-msvc" "1.3.80"
-    "@swc/core-win32-ia32-msvc" "1.3.80"
-    "@swc/core-win32-x64-msvc" "1.3.80"
-
-"@swc/types@^0.1.3":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.4.tgz#8d647e111dc97a8e2881bf71c2ee2d011698ff10"
-  integrity sha512-z/G02d+59gyyUb7KYhKi9jOhicek6QD2oMaotUyG+lUkybpXoV49dY9bj7Ah5Q+y7knK2jU67UTX9FyfGzaxQg==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -884,16 +811,6 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
-
-swc-to-babel@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/swc-to-babel/-/swc-to-babel-2.2.0.tgz#5b12be6752e5095a64bf87aff6b8fd8e27ea125d"
-  integrity sha512-7XQXZVEj/jWF49DuXPbj0fmuKbmHUxM8rxOTbRNY4IdM9ajVT3Ac4Wi08VtR40VkUu1yBsFlXoEQsN5p6x64vQ==
-  dependencies:
-    "@babel/parser" "^7.18.13"
-    "@babel/traverse" "^7.1.6"
-    "@babel/types" "^7.2.0"
-    "@swc/core" "^1.3.69"
 
 text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
It turns out that the babel AST needs to be transformed to match `espree`'s output.  We also needed to add a `parent` property on each node since eslint rules expect this property to be there.